### PR TITLE
Fix STS Gradle import issue

### DIFF
--- a/complete/build.gradle
+++ b/complete/build.gradle
@@ -58,6 +58,10 @@ task genJaxb {
 }
 // end::xsd[]
 
+task afterEclipseImport {
+	dependsOn "genJaxb"
+}
+
 // tag::jaxb[]
 configurations {
     jaxb


### PR DESCRIPTION
See: https://build.spring.io/browse/IDE-GSGUIDES-JOB1-7/test/case/163033429

genJaxb task needs to be run or classpath will be incomplete
causing build-path errors. 

This change makes the import wizard automatically execute the
task after importing the project into Eclipse so that it compiles
clean.
