### PR TITLE
Fix typo and omit curl progress messages

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -221,7 +221,7 @@ As a result you should see this response:
 </SOAP-ENV:Envelope>
 ----
 
-NOTE: Odds are that the output will be a compact XML document instead of the nicely formatted one shown above. If you have xmllib2 installed on your system, you can `curl <args above> > output.xml | xmllint --format output.xml` 
+NOTE: Odds are that the output will be a compact XML document instead of the nicely formatted one shown above. If you have xmllib2 installed on your system, you can `curl -fsSL <args above> > output.xml && xmllint --format output.xml` 
 see the results formatted nicely.
 
 == Summary


### PR DESCRIPTION
`|` caused the created document to be empty, which in turn caused the example to fail with this error message:

`target/response.xml:1: parser error : Document is empty`

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/spring-guides/gs-producing-web-service/4)

<!-- Reviewable:end -->
