### PR TITLE
Maven plugin jaxb2-maven-plugin fix and update to latest version

### DIFF
--- a/complete/pom.xml
+++ b/complete/pom.xml
@@ -46,7 +46,7 @@
 			<plugin>
 				<groupId>org.codehaus.mojo</groupId>
 				<artifactId>jaxb2-maven-plugin</artifactId>
-				<version>1.6</version>
+				<version>2.5.0</version>
 				<executions>
 					<execution>
 						<id>xjc</id>
@@ -56,9 +56,9 @@
 					</execution>
 				</executions>
 				<configuration>
-					<schemaDirectory>${project.basedir}/src/main/resources/</schemaDirectory>
-					<outputDirectory>${project.basedir}/src/main/java</outputDirectory>
-					<clearOutputDir>false</clearOutputDir>
+					<sources>
+						<source>${project.basedir}/src/main/resources/</source>
+					</sources>
 				</configuration>
 			</plugin>
 			<!-- end::xsd[] -->


### PR DESCRIPTION
* Outputs the generated sources to the default target/generated-sources/jaxb/ location as indicated by the documentation in the README.adoc. (The switch to src/main/java was introduced in https://github.com/spring-guides/gs-producing-web-service/commit/c225f4ea207db326e88b8b72ca768565f462f2a1 , but the commit message doesn't seem to indicate why.)
* Updates the jaxb2-maven-plugin to the latest 2.5.0 version