### PR TITLE
Updated gradle configuration to work under Java 11.

### DIFF
--- a/complete/build.gradle
+++ b/complete/build.gradle
@@ -80,6 +80,9 @@ dependencies {
     compile("wsdl4j:wsdl4j:1.6.1")
     jaxb("org.glassfish.jaxb:jaxb-xjc:2.2.11")
     compile(files(genJaxb.classesDir).builtBy(genJaxb))
+
+    // For Java 11:
+    implementation 'org.glassfish.jaxb:jaxb-runtime'
 }
 // end::dependencies[]
 // end::jaxb[]


### PR DESCRIPTION
Updated gradle configuration to work under Java 11. This is needed for the SOAP service to run correctly while running under Java 11. Change was made in maven, but not here.