### PR TITLE
A better suggestion about the annotation usage

### DIFF
--- a/complete/src/main/java/com/example/producingwebservice/CountryRepository.java
+++ b/complete/src/main/java/com/example/producingwebservice/CountryRepository.java
@@ -6,10 +6,10 @@ import java.util.Map;
 
 import io.spring.guides.gs_producing_web_service.Country;
 import io.spring.guides.gs_producing_web_service.Currency;
-import org.springframework.stereotype.Component;
+import org.springframework.stereotype.Repository;
 import org.springframework.util.Assert;
 
-@Component
+@Repository
 public class CountryRepository {
 	private static final Map<String, Country> countries = new HashMap<>();
 


### PR DESCRIPTION
Hi, I found that there may be some minor improvements about annotations in your code. 

A Spring bean in the persistence layer should be annotated using @Repository instead of @Component annotation.
@Repository annotation is a specialization of @Component in persistence layer. By using a specialized annotation we hit two birds with one stone. First, they are treated as Spring bean, and second, you can put special behavior required by that layer.

For better understanding and maintainability of a large application, @Repository is a better choice.