### PR TITLE
Update build.gradle

### DIFF
--- a/complete/build.gradle
+++ b/complete/build.gradle
@@ -62,6 +62,8 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-web-services'
     implementation 'wsdl4j:wsdl4j'
     jaxb("org.glassfish.jaxb:jaxb-xjc")
+    // For Java 11:
+    implementation 'org.glassfish.jaxb:jaxb-runtime'
     testImplementation('org.springframework.boot:spring-boot-starter-test')
 }
 // end::dependencies[]


### PR DESCRIPTION
Add dependency for jaxb runtime to make the solution work with new JDKs.

Same fix was already applied in the consumer side.