### PR TITLE
replicating correction made in SOAP client example into server

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -319,6 +319,36 @@ As a result, you should see the following response:
 NOTE: Odds are that the output will be a compact XML document instead of the nicely formatted one shown above. If you have xmllib2 installed on your system, you can `curl -fsSL --header "content-type: text/xml" -d @request.xml http://localhost:8080/ws > output.xml and xmllint --format output.xml`
 see the results formatted nicely.
 
+== Java 11 Caveat
+
+When running the project with java 11 and using gradle, the previous test might
+answer an error code:
+
+====
+[source,xml]
+----
+<SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/">
+    <SOAP-ENV:Header/>
+    <SOAP-ENV:Body>
+        <SOAP-ENV:Fault>
+            <faultcode>SOAP-ENV:Server</faultcode>
+            <faultstring xml:lang="en">Implementation of JAXB-API has not been found on module path or classpath.</faultstring>
+        </SOAP-ENV:Fault>
+    </SOAP-ENV:Body>
+</SOAP-ENV:Envelope>
+----
+====
+
+IMPORTANT: If that happens, either use maven, downgrade your java to 1.8 or double-check
+jaxb dependencies *javax.xml.bind:jaxb-api* and *org.glassfish.jaxb:jaxb-runtime*:
+
+====
+[source,java,indent=0]
+----
+include::complete/build.gradle[tags=dependencies]
+----
+====
+
 == Summary
 
 Congratulations! You have developed a SOAP-based service with Spring Web Services.

--- a/complete/build.gradle
+++ b/complete/build.gradle
@@ -62,6 +62,9 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-web-services'
     implementation 'wsdl4j:wsdl4j'
     jaxb("org.glassfish.jaxb:jaxb-xjc")
+    // For Java 11:
+    implementation 'javax.xml.bind:jaxb-api'
+    implementation 'org.glassfish.jaxb:jaxb-runtime'
     testImplementation('org.springframework.boot:spring-boot-starter-test')
 }
 // end::dependencies[]

--- a/complete/pom.xml
+++ b/complete/pom.xml
@@ -15,7 +15,7 @@
 	<description>Demo project for Spring Boot</description>
 
 	<properties>
-		<java.version>1.8</java.version>
+		<java.version>11</java.version>
 	</properties>
 
 	<dependencies>

--- a/complete/src/main/resources/application.properties
+++ b/complete/src/main/resources/application.properties
@@ -1,0 +1,2 @@
+logging.level.com.example.consumingwebservice=INFO
+logging.level.org.springframework.ws=DEBUG


### PR DESCRIPTION
When trying to reun locally with both server example and client example locally, The following error pops out on SOAP client:

![image](https://user-images.githubusercontent.com/556695/203674813-dbd3f027-30e7-4863-a611-ec59c98589f2.png)

It turns out this error message comes from **server**.

A quick dig into examples revealed a correction contributed by @dsyer [some time ago](https://github.com/spring-guides/gs-producing-web-service/pull/26/files) and a newer one by @huima [here](https://github.com/spring-guides/gs-producing-web-service/pull/41/files)

Would be nice to merge any of those fixes, since java 8 is slowly sunsetting yet the SOAP guide likely survive more.

And an update to the article pointing out that the error message is server-related  would be much welcome.