### PR TITLE
Replace deprecated WsConfigurerAdapter with WsConfigurer interface

### DIFF
--- a/complete/src/main/java/com/example/producingwebservice/WebServiceConfig.java
+++ b/complete/src/main/java/com/example/producingwebservice/WebServiceConfig.java
@@ -6,7 +6,7 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.io.ClassPathResource;
 import org.springframework.ws.config.annotation.EnableWs;
-import org.springframework.ws.config.annotation.WsConfigurerAdapter;
+import org.springframework.ws.config.annotation.WsConfigurer;
 import org.springframework.ws.transport.http.MessageDispatcherServlet;
 import org.springframework.ws.wsdl.wsdl11.DefaultWsdl11Definition;
 import org.springframework.xml.xsd.SimpleXsdSchema;
@@ -14,7 +14,7 @@ import org.springframework.xml.xsd.XsdSchema;
 
 @EnableWs
 @Configuration
-public class WebServiceConfig extends WsConfigurerAdapter {
+public class WebServiceConfig implements WsConfigurer {
 	@Bean
 	public ServletRegistrationBean<MessageDispatcherServlet> messageDispatcherServlet(ApplicationContext applicationContext) {
 		MessageDispatcherServlet servlet = new MessageDispatcherServlet();


### PR DESCRIPTION
This PR updates the Spring Web Services configuration to remove usage of the deprecated WsConfigurerAdapter class. Instead, the class now implements the WsConfigurer interface directly.